### PR TITLE
Separate camera from player scene

### DIFF
--- a/Scenes/Player/Player.tscn
+++ b/Scenes/Player/Player.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://Sprites/Characters/Abby/Abby_SheetWip.png" type="Texture" id=1]
 [ext_resource path="res://Scripts/Player/PlayerController.gd" type="Script" id=2]
-[ext_resource path="res://Scripts/Player/PlayerCamera.gd" type="Script" id=3]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 26.0
@@ -110,11 +109,4 @@ anims/Idle = SubResource( 6 )
 anims/RESET = SubResource( 4 )
 anims/Walk = SubResource( 5 )
 
-[node name="PlayerCam" type="Camera2D" parent="."]
-current = true
-smoothing_enabled = true
-smoothing_speed = 4.0
-script = ExtResource( 3 )
-inner_view = Vector2( 1, 1 )
-outer_view = Vector2( 1.5, 1.5 )
-zoom_speed = 6.0
+[node name="CamRemoteTransform" type="RemoteTransform2D" parent="."]

--- a/Scenes/UI/UserInterface.tscn
+++ b/Scenes/UI/UserInterface.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://Sprites/UI/Inspector/InspectableButton.png" type="Texture" id=1]
 [ext_resource path="res://Sprites/UI/Inspector/InspectableButtonHovered.png" type="Texture" id=2]
@@ -16,6 +16,7 @@
 [ext_resource path="res://Sprites/UI/SylladexButton.png" type="Texture" id=14]
 [ext_resource path="res://Sprites/UI/SylladexButtonPressed.png" type="Texture" id=15]
 [ext_resource path="res://Sprites/UI/SylladexButtonHover.png" type="Texture" id=16]
+[ext_resource path="res://Scripts/UI/Camera.gd" type="Script" id=17]
 
 [sub_resource type="Animation" id=1]
 length = 0.001
@@ -165,6 +166,15 @@ anims/SylladexClose = SubResource( 2 )
 anims/SylladexClosedIdle = SubResource( 3 )
 anims/SylladexOpen = SubResource( 4 )
 anims/SylladexOpenIdle = SubResource( 5 )
+
+[node name="Camera" type="Camera2D" parent="."]
+current = true
+smoothing_enabled = true
+smoothing_speed = 4.0
+script = ExtResource( 17 )
+inner_view = Vector2( 1, 1 )
+outer_view = Vector2( 1.5, 1.5 )
+zoom_speed = 6.0
 
 [connection signal="pressed" from="InspectableButton" to="." method="toggle_inspector"]
 [connection signal="pressed" from="CaptchableButton" to="." method="toggle_inspector"]

--- a/Scripts/Global.gd
+++ b/Scripts/Global.gd
@@ -127,6 +127,12 @@ func _change_to_room():
 		player_node.global_position = warp_target.get_position()
 		warp_target = null
 	
-	player_node.cam.global_position = player_node.global_position
+	# Since the camera's position gets updated by the player's RemoteTransform2D
+	# you don't need to manually update it anymore. However, while the camera's
+	# smoothing is enabled, this transformation will be noticeable when changing
+	# rooms. Disabling it while transitioning will fix this, but idk how to 
+	# re-enable it afterwards. YOU figure that out if you want
+#	UI.camera.smoothing_enabled = false
+#	UI.camera.global_position = player_node.remote_transform.global_position
 	
 	sequence_active = false

--- a/Scripts/Player/PlayerController.gd
+++ b/Scripts/Player/PlayerController.gd
@@ -19,10 +19,14 @@ var back_sprite : bool = false
 
 onready var sprite = $CharSprite
 onready var animator = $PlayerAnimator
-# For some reason I have a reference to the player camera here. This isn't used anywhere lol.
-# Player camera will eventually be independent from the main player, probably, so I can have the camera
-# move to focus on different areas of the room for cinematics and other shit.
-onready var cam = $PlayerCam
+# RemoteTransform2D to make the camera in the globally available UI scene
+# follow the player around. You can probably animate this node's position
+# for cinematics and such. Currently has the quirk of making the camera very
+# noticeably tween towards the player when loading into a scene
+onready var remote_transform : RemoteTransform2D = $CamRemoteTransform
+
+func _ready() -> void:
+	remote_transform.remote_path = UI.camera.get_path()
 
 func _process(_delta):
 	if !Global.sequence_active:
@@ -58,4 +62,5 @@ func _physics_process(delta):
 		else:
 			animator.play("BackIdle")
 	
+# warning-ignore:return_value_discarded
 	move_and_slide(move_velocity * move_speed)

--- a/Scripts/UI/Camera.gd
+++ b/Scripts/UI/Camera.gd
@@ -3,6 +3,7 @@ extends Camera2D
 # Just a zoom for the player camera. Scroll in, zoom in. Scroll out, zoom out.
 # That's all there really is to say on the matter.
 # // TODO: Have the camera independent/not a child of the player so it can move to other look-at targets? \\
+# // ^ Done :) -Sharkalien\\ 
 
 export var inner_view : Vector2
 export var outer_view : Vector2

--- a/Scripts/UI/CaptchaCard.gd
+++ b/Scripts/UI/CaptchaCard.gd
@@ -23,7 +23,7 @@ func _input(event):
 		
 		texture = normal_sprite
 
-func _process(delta):
+func _process(_delta):
 	if !card_highlighted:
 		texture = normal_sprite
 

--- a/Scripts/UI/PlayerInterface.gd
+++ b/Scripts/UI/PlayerInterface.gd
@@ -22,6 +22,8 @@ onready var dialogue_box = $DialogueBox
 onready var dialogue_text = $DialogueBox/InnerPanel/DialogueText
 onready var help_button = $HelpButton
 
+onready var camera = $Camera
+
 func _input(event):
 	if event.is_action_released("toggle_inspector"):
 		toggle_inspector()


### PR DESCRIPTION
Moved the camera from the player scene into the globally available UI scene. 

The newly added RemoteTransform2D node in the player now control's the camera's position, and you can probably use ANOTHER RemoteTransform2D to animate THAT node for cinematics and such.