### PR TITLE
Make CaptchaCard a TextureButton

### DIFF
--- a/Scenes/Player/Player.tscn
+++ b/Scenes/Player/Player.tscn
@@ -64,7 +64,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ 4 ]
+"values": [ 8 ]
 }
 
 [sub_resource type="Animation" id=5]
@@ -95,7 +95,7 @@ deceleration = 100.0
 texture = ExtResource( 1 )
 hframes = 4
 vframes = 4
-frame = 4
+frame = 8
 
 [node name="PlayerCol" type="CollisionShape2D" parent="."]
 position = Vector2( 0, 103 )

--- a/Scenes/UI/CaptchaCard.tscn
+++ b/Scenes/UI/CaptchaCard.tscn
@@ -17,7 +17,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Vector2( -23.5, -30.5 ) ]
+"values": [ Vector2( 0, 2 ) ]
 }
 
 [sub_resource type="Animation" id=2]
@@ -32,21 +32,20 @@ tracks/0/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Vector2( -23.5, -32.5 ) ]
+"values": [ Vector2( 0, 0 ) ]
 }
 
-[node name="CaptchaCard" type="Node2D"]
+[node name="CaptchaCard" type="Control"]
+margin_left = -23.0
+margin_top = -32.0
+margin_right = 24.0
+margin_bottom = 33.0
+rect_min_size = Vector2( 47, 0 )
 script = ExtResource( 4 )
 
 [node name="CardButton" type="TextureButton" parent="."]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -23.5
-margin_top = -32.5
-margin_right = 23.5
-margin_bottom = 32.5
+margin_right = 47.0
+margin_bottom = 65.0
 texture_normal = ExtResource( 1 )
 texture_pressed = ExtResource( 2 )
 texture_hover = ExtResource( 1 )

--- a/Scenes/UI/CaptchaCard.tscn
+++ b/Scenes/UI/CaptchaCard.tscn
@@ -1,24 +1,64 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://Sprites/UI/Sylladex/CaptchaCard.png" type="Texture" id=1]
+[ext_resource path="res://Sprites/UI/Sylladex/CaptchaCardHovered.png" type="Texture" id=2]
 [ext_resource path="res://Scripts/UI/CaptchaCard.gd" type="Script" id=4]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 24, 32 )
+[sub_resource type="Animation" id=1]
+resource_name = "Hover"
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("CardButton:rect_position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( -23.5, -30.5 ) ]
+}
 
-[node name="CaptchaCard" type="Sprite"]
-texture = ExtResource( 1 )
+[sub_resource type="Animation" id=2]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("CardButton:rect_position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( -23.5, -32.5 ) ]
+}
+
+[node name="CaptchaCard" type="Node2D"]
 script = ExtResource( 4 )
-hover_pos = Vector2( 0, 2 )
 
-[node name="ItemSprite" type="Sprite" parent="."]
-position = Vector2( -2, 2 )
+[node name="CardButton" type="TextureButton" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -23.5
+margin_top = -32.5
+margin_right = 23.5
+margin_bottom = 32.5
+texture_normal = ExtResource( 1 )
+texture_pressed = ExtResource( 2 )
+texture_hover = ExtResource( 1 )
+
+[node name="ItemSprite" type="Sprite" parent="CardButton"]
+position = Vector2( 21.5, 36.5 )
 scale = Vector2( 0.4, 0.4 )
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+anims/Hover = SubResource( 1 )
+anims/RESET = SubResource( 2 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource( 1 )
-
-[connection signal="mouse_entered" from="Area2D" to="." method="_on_Area2D_mouse_entered"]
-[connection signal="mouse_exited" from="Area2D" to="." method="_on_Area2D_mouse_exited"]
+[connection signal="mouse_entered" from="CardButton" to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="CardButton" to="." method="_on_mouse_exited"]
+[connection signal="pressed" from="CardButton" to="." method="_on_CardButton_pressed"]

--- a/Scenes/UI/Sylladex.tscn
+++ b/Scenes/UI/Sylladex.tscn
@@ -11,33 +11,64 @@ font_data = ExtResource( 3 )
 
 [node name="Sylladex" type="Node2D"]
 script = ExtResource( 2 )
-cards = [ NodePath("Background/Card1"), NodePath("Background/Card2"), NodePath("Background/Card3"), NodePath("Background/Card4"), NodePath("Background/Card5"), NodePath("Background/Card6"), NodePath("Background/Card7") ]
 
 [node name="Background" type="Sprite" parent="."]
 position = Vector2( 512, 520 )
 scale = Vector2( 1.57538, 1.6 )
 texture = ExtResource( 1 )
 
-[node name="Card1" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( -183.434, 12.5 )
+[node name="CardsContainer" type="HBoxContainer" parent="Background"]
+anchor_top = 0.25
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -325.0
+margin_top = -45.0
+margin_right = -325.0
+margin_bottom = -50.0
+custom_constants/separation = 20
+alignment = 1
 
-[node name="Card2" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( -122.497, 12.5 )
+[node name="Card1" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 100.0
+margin_top = 0.0
+margin_right = 147.0
+margin_bottom = 70.0
 
-[node name="Card3" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( -60.9377, 12.5 )
+[node name="Card2" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 167.0
+margin_top = 0.0
+margin_right = 214.0
+margin_bottom = 70.0
 
-[node name="Card4" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( 0, 12.5 )
+[node name="Card3" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 234.0
+margin_top = 0.0
+margin_right = 281.0
+margin_bottom = 70.0
 
-[node name="Card5" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( 60.9377, 12.5 )
+[node name="Card4" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 301.0
+margin_top = 0.0
+margin_right = 348.0
+margin_bottom = 70.0
 
-[node name="Card6" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( 122.524, 12.5 )
+[node name="Card5" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 368.0
+margin_top = 0.0
+margin_right = 415.0
+margin_bottom = 70.0
 
-[node name="Card7" parent="Background" instance=ExtResource( 7 )]
-position = Vector2( 183.461, 12.5 )
+[node name="Card6" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 435.0
+margin_top = 0.0
+margin_right = 482.0
+margin_bottom = 70.0
+
+[node name="Card7" parent="Background/CardsContainer" instance=ExtResource( 7 )]
+margin_left = 502.0
+margin_top = 0.0
+margin_right = 549.0
+margin_bottom = 70.0
 
 [node name="ItemNameDisplay" type="RichTextLabel" parent="."]
 margin_left = 848.0

--- a/Scenes/UI/UserInterface.tscn
+++ b/Scenes/UI/UserInterface.tscn
@@ -152,6 +152,7 @@ margin_left = 128.0
 margin_top = 368.0
 margin_right = 896.0
 margin_bottom = 576.0
+mouse_filter = 0
 
 [node name="FadeOverlay" type="ColorRect" parent="."]
 visible = false

--- a/Scripts/UI/CaptchaCard.gd
+++ b/Scripts/UI/CaptchaCard.gd
@@ -1,5 +1,5 @@
 class_name CaptchaCard
-extends Node2D
+extends Control
 
 var current_item : String
 var current_description = []

--- a/Scripts/UI/CaptchaCard.gd
+++ b/Scripts/UI/CaptchaCard.gd
@@ -1,40 +1,23 @@
 class_name CaptchaCard
-extends Sprite
+extends Node2D
 
 var current_item : String
 var current_description = []
-onready var item_sprite = $ItemSprite
-
-export var hover_pos : Vector2
-onready var normal_pos : Vector2 = position
+onready var item_sprite = $CardButton/ItemSprite
+onready var anim_player : AnimationPlayer = $AnimationPlayer
 
 var card_highlighted : bool = false
-var normal_sprite = preload("res://Sprites/UI/Sylladex/CaptchaCard.png")
-var pressed_sprite = preload("res://Sprites/UI/Sylladex/CaptchaCardHovered.png")
 onready var sylladex = Global.sylladex
 
-func _input(event):
-	if event.is_action_pressed("submit") and card_highlighted:
-		texture = pressed_sprite
-	
-	if event.is_action_released("submit") and card_highlighted:
-		if !current_item.empty():
-			Global.dialogue.trigger_dialogue(current_description)
-		
-		texture = normal_sprite
-
-func _process(_delta):
-	if !card_highlighted:
-		texture = normal_sprite
-
-func _on_Area2D_mouse_entered():
-	card_highlighted = true
-	position += hover_pos
-	
+func _on_mouse_entered():
+	anim_player.play("Hover")
 	if current_item != "":
 		sylladex.name_display.text = current_item
 
-func _on_Area2D_mouse_exited():
-	card_highlighted = false
-	position = normal_pos
+func _on_mouse_exited():
 	sylladex.name_display.text = ""
+	anim_player.play("RESET")
+
+func _on_CardButton_pressed() -> void:
+	if !current_item.empty():
+		Global.dialogue.trigger_dialogue(current_description)

--- a/Scripts/UI/Sylladex.gd
+++ b/Scripts/UI/Sylladex.gd
@@ -33,8 +33,9 @@ func add_item(item : String, dialog, sprite : Texture):
 			card.current_description = dialog
 			card.item_sprite.texture = sprite
 			card.anim_player.play("Hover")
-			yield(get_tree().create_timer(0.02), "timeout")
+			yield(get_tree().create_timer(0.04), "timeout")
 			card.anim_player.play("RESET")
+			yield(get_tree().create_timer(0.04), "timeout")
 			if !UI.sylladex_open:
 				UI.close_sylladex()
 			

--- a/Scripts/UI/Sylladex.gd
+++ b/Scripts/UI/Sylladex.gd
@@ -32,10 +32,9 @@ func add_item(item : String, dialog, sprite : Texture):
 			card.current_item = item
 			card.current_description = dialog
 			card.item_sprite.texture = sprite
-			card.position += card.hover_pos
-			yield(get_tree().create_timer(0.04), "timeout")
-			card.position = card.normal_pos
-			yield(get_tree().create_timer(0.4), "timeout")
+			card.anim_player.play("Hover")
+			yield(get_tree().create_timer(0.02), "timeout")
+			card.anim_player.play("RESET")
 			if !UI.sylladex_open:
 				UI.close_sylladex()
 			

--- a/Scripts/UI/Sylladex.gd
+++ b/Scripts/UI/Sylladex.gd
@@ -6,7 +6,7 @@ extends Node2D
 # If you attempt to captchalogue an item and your Sylladex is full, you wont captchalogue it until you use an item
 # Used items are destroyed, or "expended", though that can be toggled on a per-interaction basis
 # Primarily just a way of carrying around items like in your average point and click adventure to solve puzzles n whatnot
-export(Array, NodePath) var cards = []
+onready var cards = $Background/CardsContainer.get_children()
 var full_dialogue = ["You can't CAPTCHALOGUE anything right now! Your SYLLADEX is full!"]
 onready var name_display = $ItemNameDisplay
 
@@ -17,8 +17,7 @@ onready var name_display = $ItemNameDisplay
 # // TODO: Convert it into a custom Resource instead to alleviate that mess? \\
 # This doesn't look the most elegant but it works fine. Good enough for me!
 func add_item(item : String, dialog, sprite : Texture):
-	for c in cards:
-		var card = get_node(c)
+	for card in cards:
 		if card.current_item.empty():
 			Global.sequence_active = true
 			# Wanted to have different delay times depending on if the sylladex was already opened or not
@@ -49,8 +48,7 @@ func add_item(item : String, dialog, sprite : Texture):
 # Same as adding an item, loop through all the cards; if its current_item matches the target string,
 # then we just get rid of the item. Gone. Reduced to atoms.
 func remove_item(target : String):
-	for c in cards:
-		var card = get_node(c)
+	for card in cards:
 		if card.current_item.to_upper() == target.to_upper():
 			card.current_item = ""
 			card.current_description = []
@@ -61,8 +59,7 @@ func remove_item(target : String):
 # Loop through all the cards; if it has the target string as its current_item,
 # then return true. Otherwise return false.
 func has_item(target : String) -> bool:
-	for c in cards:
-		var card = get_node(c)
+	for card in cards:
 		if !card.current_item.empty() and card.current_item.to_upper() == target.to_upper():
 			return true
 	

--- a/project.godot
+++ b/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "Node2D",
+"base": "Control",
 "class": "CaptchaCard",
 "language": "GDScript",
 "path": "res://Scripts/UI/CaptchaCard.gd"

--- a/project.godot
+++ b/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "Sprite",
+"base": "Node2D",
 "class": "CaptchaCard",
 "language": "GDScript",
 "path": "res://Scripts/UI/CaptchaCard.gd"
@@ -160,7 +160,7 @@ toggle_inspector={
 }
 submit={
 "deadzone": 0.5,
-"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]


### PR DESCRIPTION
Plus some minor tweaks; changed Player's anim reset track to the idle frame, and made the "submit" input button receive input from all devices, to make it touch screen compatible.

Using an Area2D's input event signal for mouse events can be a bit problematic, as you can't limit the input it receives when another node is layered on top of it, causing the player to be able to continuously trigger the event despite not meaning to. Control nodes are better in this regard, since you're able to filter those events. 

Although this isn't necessarily the reason why I changed the CaptchaCard to a TextureButton (that was more for refactoring), I did change the DialogueBox's mouse filter property to "Stop", since you could keep clicking on captchalogued items in the captchalogue deck through it, triggering the text again and again.